### PR TITLE
Changed from MongoRepository to JpaRepo

### DIFF
--- a/tg-register-backend/src/main/java/com/tourist/app/repository/UserRepository.java
+++ b/tg-register-backend/src/main/java/com/tourist/app/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.tourist.app.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.tourist.app.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+
+}


### PR DESCRIPTION
As Entity class was changed into RDBMS from Mongo so, Jparepository  was needed.